### PR TITLE
tweak: Screentip position

### DIFF
--- a/modular_ss220/modular_ss220.dme
+++ b/modular_ss220/modular_ss220.dme
@@ -6,4 +6,5 @@
 #include "_span/_span.dme"
 #include "fullscreen/_fullscreen.dme"
 #include "keybindings/_keybindings.dme"
+#include "screentip_change/_screentip_change.dme"
 #include "title_screen/_title_screen.dme"

--- a/modular_ss220/screentip_change/_screentip_change.dm
+++ b/modular_ss220/screentip_change/_screentip_change.dm
@@ -1,0 +1,4 @@
+/datum/modpack/screentip_change
+	name = "Сдвиг Screentip вверх"
+	desc = "Меняет местоположение Screentip, чтобы они были выше."
+	author = "larentoun"

--- a/modular_ss220/screentip_change/_screentip_change.dme
+++ b/modular_ss220/screentip_change/_screentip_change.dme
@@ -1,0 +1,3 @@
+#include "_screentip_change.dm"
+
+#include "code/screentip.dm"

--- a/modular_ss220/screentip_change/code/screentip.dm
+++ b/modular_ss220/screentip_change/code/screentip.dm
@@ -1,0 +1,2 @@
+/obj/screen/screentip
+	maptext_y = 0


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #1234" (где 1234 - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

Сменяет позицию Screentips на 50 пикселей вверх

fixes https://github.com/ss220club/Paradise-Remake/issues/18

## Почему это хорошо для игры

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

Скриптип не лезет в глаза

## Changelog

:cl:
tweak: Смена позиции Screentips на 50 пикселей вверх
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
