### PR TITLE
fix: fix another pack of gliding issues

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -160,82 +160,21 @@
 
 /atom/movable/Move(atom/newloc, direction, glide_size_override = 0)
 	. = FALSE
-	if(!newloc || newloc == loc)
-		return
-
 	if(!direction)
 		direction = get_dir(src, newloc)
 
-	if(dir != direction)
-		setDir(direction)
-
-	// var/is_multi_tile_object = is_multi_tile_object(src)
-
-	// var/list/old_locs
-	// if(is_multi_tile_object && isturf(loc))
-	// 	old_locs = locs // locs is a special list, this is effectively the same as .Copy() but with less steps
-	// 	for(var/atom/exiting_loc as anything in old_locs)
-	// 		if(!exiting_loc.Exit(src, direction))
-	// 			return
-	// else if(!loc.Exit(src, direction))
-	// 	return
-
-	// var/list/new_locs
-	// if(is_multi_tile_object && isturf(newloc))
-	// 	new_locs = block(
-	// 		newloc,
-	// 		locate(
-	// 			min(world.maxx, newloc.x + CEILING(bound_width / 32, 1)),
-	// 			min(world.maxy, newloc.y + CEILING(bound_height / 32, 1)),
-	// 			newloc.z
-	// 			)
-	// 	) // If this is a multi-tile object then we need to predict the new locs and check if they allow our entrance.
-	// 	for(var/atom/entering_loc as anything in new_locs)
-	// 		if(!entering_loc.Enter(src))
-	// 			return
-	// 		if(SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_MOVE, entering_loc) & COMPONENT_MOVABLE_BLOCK_PRE_MOVE)
-	// 			return
-	// else // Else just try to enter the single destination.
-	// 	if(!newloc.Enter(src))
-	// 		return
-	// 	if(SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_MOVE, newloc) & COMPONENT_MOVABLE_BLOCK_PRE_MOVE)
-	// 		return
-
 	// Past this is the point of no return
 	var/atom/oldloc = loc
-	// var/area/oldarea = get_area(oldloc)
-	// var/area/newarea = get_area(newloc)
-
 	if(SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_MOVE, newloc) & COMPONENT_MOVABLE_BLOCK_PRE_MOVE)
 		return
 	. = ..(newloc, direction)
-
-	// if(old_locs) // This condition will only be true if it is a multi-tile object.
-	// 	for(var/atom/exited_loc as anything in (old_locs - new_locs))
-	// 		exited_loc.Exited(src, direction)
-	// else // Else there's just one loc to be exited.
-	// 	oldloc.Exited(src, direction)
-	// if(oldarea != newarea)
-	// 	oldarea.Exited(src, direction)
-
-	// if(new_locs) // Same here, only if multi-tile.
-	// 	for(var/atom/entered_loc as anything in (new_locs - old_locs))
-	// 		entered_loc.Entered(src, oldloc, old_locs)
-	// else
-	// 	newloc.Entered(src, oldloc, old_locs)
-	// if(oldarea != newarea)
-	// 	newarea.Entered(src, oldarea)
-
 	if (.)
 		Moved(oldloc, direction, FALSE)
-		last_move = direction
-		move_speed = world.time - l_move_time
-		l_move_time = world.time
 
 ///////////////////////////////////////////////////////
 
 /atom/movable/Move(atom/newloc, direction, glide_size_override = 0)
-	if(!loc || !newloc)
+	if(!loc || !newloc || newloc == loc)
 		return FALSE
 
 	var/atom/oldloc = loc
@@ -243,8 +182,12 @@
 	if(glide_size_override && glide_size != glide_size_override)
 		set_glide_size(glide_size_override)
 
+
 	if(loc != newloc)
-		. = IS_DIR_DIAGONAL(direction) ? MoveDiagonally(direction) : ..()
+		if (IS_DIR_DIAGONAL(direction))
+			. = MoveDiagonally(direction)
+		else
+			. = ..()
 
 	if(!loc || (loc == oldloc && oldloc != newloc))
 		last_move = 0
@@ -255,12 +198,12 @@
 	if(glide_size_override)
 		set_glide_size(glide_size_override)
 
-	last_move = direction
-
-	if(dir != direction)
-		setDir(direction)
-	if(. && has_buckled_mobs() && !handle_buckled_mob_movement(loc, direction, glide_size_override)) //movement failed due to buckled mob(s)
+	if(. && !handle_buckled_mob_movement(loc, direction, glide_size_override)) //movement failed due to buckled mob(s)
 		. = FALSE
+
+	last_move = direction
+	move_speed = world.time - l_move_time
+	l_move_time = world.time
 
 /atom/movable/proc/MoveDiagonally(direction)
 	moving_diagonally = FIRST_DIAG_STEP

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -512,7 +512,7 @@ emp_act
 			bloody = 1
 			var/turf/location = loc
 			if(issimulatedturf(location))
-				add_splatter_floor(location, emittor_intertia = inertia_next_move > world.time ? last_movement_dir : null)
+				add_splatter_floor(location, emittor_intertia = inertia_next_move > world.time ? last_move : null)
 			if(ishuman(user))
 				var/mob/living/carbon/human/H = user
 				if(get_dist(H, src) <= 1) //people with TK won't get smeared with blood

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -40,6 +40,12 @@
 	update_runechat_msg_location()
 	. = ..()
 
+/// Le Crutch to make mobs not controlled by the player, to actually glide from tile to tile. This will remain here, until the mob movement refactor.
+/mob/Move(atom/newloc, direction, glide_size_override = 0)
+	if (!glide_size_override && !moving_diagonally)
+		glide_size_override =  DELAY_TO_GLIDE_SIZE(movement_delay())
+	. = ..()
+
 /atom/proc/prepare_huds()
 	hud_list = list()
 	for(var/hud in hud_possible)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -133,17 +133,16 @@
 
 	//We are now going to move
 	moving = 1
+
 	var/add_delay = mob.movement_delay()
-	mob.set_glide_size(DELAY_TO_GLIDE_SIZE(add_delay * ((IS_DIR_DIAGONAL(direct)) ? sqrt(2) : 1 )))
+	if(locate(/obj/item/grab, mob))
+		add_delay += 7
 
 	if(old_move_delay + world.tick_lag > world.time)
 		move_delay = old_move_delay
 	else
 		move_delay = world.time
 	mob.last_movement = world.time
-
-	if(locate(/obj/item/grab, mob))
-		add_delay += 7
 
 	if(istype(living_mob))
 		var/newdir = NONE
@@ -158,27 +157,15 @@
 			direct = newdir
 			new_loc = get_step(mob, direct)
 
-	mob.last_movement_dir = direct
-
-	var/prev_pulling_loc = null
-	if(mob.pulling)
-		prev_pulling_loc = mob.pulling.loc
-
-	. = ..()
+	. = mob.Move(new_loc, direct, DELAY_TO_GLIDE_SIZE(add_delay * (IS_DIR_DIAGONAL(direct) ? sqrt(2) : 1)))
 
 	if(IS_DIR_DIAGONAL(direct) && mob.loc == new_loc) //moved diagonally successfully
 		add_delay *= sqrt(2)
+
 	mob.set_glide_size(DELAY_TO_GLIDE_SIZE(add_delay))
+	mob.pulling?.set_glide_size(mob.glide_size)
 
 	move_delay += add_delay
-
-	if(mob.pulledby)
-		mob.pulledby.stop_pulling()
-
-	if(prev_pulling_loc && mob.pulling?.face_while_pulling && (mob.pulling.loc != prev_pulling_loc))
-		mob.setDir(get_dir(mob, mob.pulling)) // Face welding tanks and stuff when pulling
-	else
-		mob.setDir(direct)
 
 	moving = 0
 	if(mob && .)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -167,6 +167,9 @@
 
 	move_delay += add_delay
 
+	if(mob.pulledby)
+		mob.pulledby.stop_pulling()
+
 	moving = 0
 	if(mob && .)
 		if(mob.throwing)

--- a/code/modules/mob/mob_vars.dm
+++ b/code/modules/mob/mob_vars.dm
@@ -188,9 +188,6 @@
 
 	var/last_movement = -100 // Last world.time the mob actually moved of its own accord.
 
-	/// The direction they last moved
-	var/last_movement_dir
-
 	var/last_logout = 0
 
 	var/resize = 1 //Badminnery resize

--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -87,9 +87,9 @@
 		blood_volume = max(blood_volume - amt, 0)
 		if(isturf(loc)) //Blood loss still happens in locker, floor stays clean
 			if(amt >= 10)
-				add_splatter_floor(loc, emittor_intertia = inertia_next_move > world.time ? last_movement_dir : null)
+				add_splatter_floor(loc, emittor_intertia = inertia_next_move > world.time ? last_move : null)
 			else
-				add_splatter_floor(loc, 1, emittor_intertia = inertia_next_move > world.time ? last_movement_dir : null)
+				add_splatter_floor(loc, 1, emittor_intertia = inertia_next_move > world.time ? last_move : null)
 
 /mob/living/carbon/human/bleed(amt)
 	amt *= physiology.bleed_mod
@@ -108,7 +108,7 @@
 		blood_volume = max(blood_volume - amt, 0)
 		if(prob(10 * amt)) // +5% chance per internal bleeding site that we'll cough up blood on a given tick.
 			custom_emote(EMOTE_VISIBLE, "coughs up blood!")
-			add_splatter_floor(loc, 1, emittor_intertia = inertia_next_move > world.time ? last_movement_dir : null)
+			add_splatter_floor(loc, 1, emittor_intertia = inertia_next_move > world.time ? last_move : null)
 			return 1
 		else if(amt >= 1 && prob(5 * amt)) // +2.5% chance per internal bleeding site that we'll cough up blood on a given tick. Must be bleeding internally in more than one place to have a chance at this.
 			vomit(0, 1)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Исправляет еще пачку проблем с глайдингом, а именно когда при диагональном хождении в стену с пуленым обьектом, диагональное движение на vehicle, а так же выбо направления куклы при диагональной попытке передвижения в стену

## Changelog

:cl:
fix: запуленый обьект не дёргается при движении при диагональном движении  в стену, когда движение успешно
fix: сигвей и другие vehicle адеватно двигаются по диагонали
fix: все некотролируемые клиентом мобы имеют более-менее адекватный глайдинг
fix: правильный глайдинг при грабе
/:cl: