### PR TITLE
fix: update gun appearance flags, set default mob gliding to 8 (atom movable's value)

### DIFF
--- a/code/modules/mob/mob_vars.dm
+++ b/code/modules/mob/mob_vars.dm
@@ -1,7 +1,6 @@
 /mob
 	density = TRUE
 	layer = MOB_LAYER
-	glide_size = 1.5
 	animate_movement = 2
 	pressure_resistance = 8
 	throwforce = 10

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -15,6 +15,7 @@
 	origin_tech = "combat=1"
 	needs_permit = TRUE
 	attack_verb = list("struck", "hit", "bashed")
+	appearance_flags = TILE_BOUND|PIXEL_SCALE|LONG_GLIDE|KEEP_TOGETHER
 
 	var/fire_sound = "gunshot"
 	var/magin_sound = 'sound/weapons/gun_interactions/smg_magin.ogg'


### PR DESCRIPTION

## Что этот PR делает

Update gun appearance flags, set default mob gliding to 8 (atom movable's value)

## Changelog

:cl:
fix: делает перемещение мобов, управляемыми игроком плавнее
fix: весь спрайт оружия трансформируется как одно целое (все оверлеи считаются частью спрайта)
/:cl:
